### PR TITLE
change test and solution on highest-number for multiple digits examples

### DIFF
--- a/highest-number/solutions/highest-number.reduce.ts
+++ b/highest-number/solutions/highest-number.reduce.ts
@@ -1,0 +1,3 @@
+export function getHighestNumber(numbers: number[]): number {
+  return numbers.reduce((acc, value) => (value > acc ? value : acc))
+}

--- a/highest-number/solutions/highest-number.sort.ts
+++ b/highest-number/solutions/highest-number.sort.ts
@@ -1,0 +1,3 @@
+export function getHighestNumber(numbers: number[]): number {
+  return numbers.slice().sort((num1, num2) => num1 - num2)[numbers.length - 1]
+}

--- a/highest-number/solutions/highest-number.spec.ts
+++ b/highest-number/solutions/highest-number.spec.ts
@@ -10,10 +10,10 @@ describe('getHighestNumber', () => {
   })
 
   it('should get the highest number given an array of several numbers', () => {
-    const given = [1, 3, 2]
+    const given = [1, 10, 3]
 
     const actual = getHighestNumber(given)
 
-    expect(actual).toBe(3)
+    expect(actual).toBe(10)
   })
 })

--- a/highest-number/solutions/highest-number.spec.ts
+++ b/highest-number/solutions/highest-number.spec.ts
@@ -1,4 +1,4 @@
-import { getHighestNumber } from './highest-number'
+import { getHighestNumber } from './highest-number.sort'
 
 describe('getHighestNumber', () => {
   it('should get the highest number given an array of one number', () => {

--- a/highest-number/solutions/highest-number.ts
+++ b/highest-number/solutions/highest-number.ts
@@ -1,3 +1,0 @@
-export function getHighestNumber(numbers: number[]): number {
-  return numbers.reduce((acc: number, value: number) => (value > acc ? value : acc))
-}

--- a/highest-number/solutions/highest-number.ts
+++ b/highest-number/solutions/highest-number.ts
@@ -1,3 +1,3 @@
 export function getHighestNumber(numbers: number[]): number {
-  return numbers.slice().sort()[numbers.length - 1]
+  return numbers.reduce((acc: number, value: number) => (value > acc ? value : acc))
 }


### PR DESCRIPTION
If numbers contains multiple digits orders, by default, the sort() function sorts values as strings, causing incorrect results.
Can be resolved using a sort callback (`sort(function(a, b){return a - b})`) or using a reduce function